### PR TITLE
Turtle 움직임에 대한 왼쪽 오른쪽 변경사항 추가

### DIFF
--- a/scripts/cmd_turtle.py
+++ b/scripts/cmd_turtle.py
@@ -17,22 +17,16 @@ class WhereToGo():
         twist_msg = Twist()
 
         if _string_msg.data == "go":
-            twist_msg.linear.x = 3.0
+            twist_msg.linear.x = 2.0
             twist_msg.angular.z = 0.0
         
         elif _string_msg.data == "left":
-            twist_msg.linear.x = 0.0
-            twist_msg.linear.y = 1.0
-            twist_msg.angular.z = 0.0
+            twist_msg.linear.x = 2.0
+            twist_msg.angular.z = 1.5
             
         elif _string_msg.data == "right":
-            twist_msg.linear.x = 0.0
-            twist_msg.linear.y =  - 1.0
-            twist_msg.angular.z = 0.0
-        elif _string_msg.data == "turn":
-            twist_msg.linear.x = 0.0
-            twist_msg.linear.y =  0.0
-            twist_msg.angular.z = 1.5
+            twist_msg.linear.x = 2.0
+            twist_msg.angular.z = -1.5
         
         else:
             rospy.logwarn("input String should be 'go', 'left', 'right', try again")

--- a/scripts/cmd_turtle.py
+++ b/scripts/cmd_turtle.py
@@ -17,16 +17,22 @@ class WhereToGo():
         twist_msg = Twist()
 
         if _string_msg.data == "go":
-            twist_msg.linear.x = 2.0
+            twist_msg.linear.x = 3.0
             twist_msg.angular.z = 0.0
         
         elif _string_msg.data == "left":
-            twist_msg.linear.x = 2.0
-            twist_msg.angular.z = 1.5
+            twist_msg.linear.x = 0.0
+            twist_msg.linear.y = 1.0
+            twist_msg.angular.z = 0.0
             
         elif _string_msg.data == "right":
-            twist_msg.linear.x = 2.0
-            twist_msg.angular.z = -1.5
+            twist_msg.linear.x = 0.0
+            twist_msg.linear.y =  - 1.0
+            twist_msg.angular.z = 0.0
+        elif _string_msg.data == "turn":
+            twist_msg.linear.x = 0.0
+            twist_msg.linear.y =  0.0
+            twist_msg.angular.z = 1.5
         
         else:
             rospy.logwarn("input String should be 'go', 'left', 'right', try again")

--- a/scripts/cmd_turtle.py
+++ b/scripts/cmd_turtle.py
@@ -21,12 +21,10 @@ class WhereToGo():
             twist_msg.angular.z = 0.0
         
         elif _string_msg.data == "left":
-            twist_msg.linear.x = 2.0
-            twist_msg.angular.z = 1.5
+            twist_msg.linear.y = 2.0
             
         elif _string_msg.data == "right":
-            twist_msg.linear.x = 2.0
-            twist_msg.angular.z = -1.5
+            twist_msg.linear.y = 2.0
         
         else:
             rospy.logwarn("input String should be 'go', 'left', 'right', try again")

--- a/scripts/cmd_turtle_using_input.py
+++ b/scripts/cmd_turtle_using_input.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+# testing code
+# 김재훈 선임 연구원님이 피드백해주신 내 코드 + WeGo의 Convention rule 적용
+
+import rospy
+from geometry_msgs.msg import Twist
+
+# return None
+def go(_msg=Twist(), _pub=rospy.Publisher("cmd_vel", Twist, queue_size=1)):
+    _msg.linear.x = 2.0
+    _msg.angular.z = 0.0
+    _pub.publish(_msg)
+
+# return None
+def right(_msg=Twist(), _pub=rospy.Publisher("cmd_vel", Twist, queue_size=1)):
+    _msg.linear.x = 2
+    _msg.angular.z = -1.5
+    _pub.publish(_msg)
+
+# return None
+def left(_msg=Twist(), _pub=rospy.Publisher("cmd_vel", Twist, queue_size=1)):
+    _msg.linear.x = 2
+    _msg.angular.z = 1.5
+    _pub.publish(_msg)
+
+if __name__ == '__main__':
+    rospy.init_node("cmd_vel")
+    cmd_vel_pub = rospy.Publisher("/turtle1/cmd_vel",Twist,queue_size=10)
+    drive_msg = Twist()
+    direction = ""
+    try:
+        while direction != "stop":
+            direction = raw_input("go or left or right, stop for quit : ")
+        
+            if direction == "go":
+                go(drive_msg, cmd_vel_pub)            
+            elif direction == "left":
+                left(drive_msg, cmd_vel_pub)
+            elif direction == "right":
+                right(drive_msg, cmd_vel_pub)
+        
+        
+    except Exception as e:
+        rospy.logwarn("Please Input One of These : go, left, right, stop")
+        rospy.logwarn(e)


### PR DESCRIPTION
cmd_turtle.py
- string_callback 내부의 left, right인 경우에 대한 수정
- left일 때, 기존에는 왼쪽 회전하던 방식을 왼쪽으로 이동하는 방식으로 변경
- right일 때, 기존에는 오른쪽 회전하던 방식을 오른쪽으로 이동하는 방식으로 변경